### PR TITLE
Allow set optional `pre_hook` command while defining pattern

### DIFF
--- a/autoload/shebang.vim
+++ b/autoload/shebang.vim
@@ -50,6 +50,8 @@ fun! s:detect_filetype_test(line, patterns, expected) " {{{ test
 endf " }}}
 fun! shebang#unittest() " {{{ all tests
   let patterns = {
+        \ '^#!.*[s]\?bin/sh\>' : 'sh',
+        \ '^#!.*[s]\?bin/bash\>' : 'sh',
         \ '^#!.*\s\+\(ba\|c\|a\|da\|k\|pdk\|mk\|tc\)\?sh\>' : 'sh',
         \ '^#!.*\s\+zsh\>'                                  : 'zsh',
         \ '^#!.*\s\+ruby\>'                                 : 'ruby',
@@ -59,6 +61,16 @@ fun! shebang#unittest() " {{{ all tests
         \ '^#!.*\s\+node\>'                                 : 'javascript',
         \ }
   " shells
+  call s:detect_filetype_test('#!/usr/sbin/sh'        , patterns , 'sh')
+  call s:detect_filetype_test('#!/usr/bin/sh'         , patterns , 'sh')
+  call s:detect_filetype_test('#!/sbin/sh'            , patterns , 'sh')
+  call s:detect_filetype_test('#!/bin/sh'             , patterns , 'sh')
+
+  call s:detect_filetype_test('#!/usr/sbin/bash'      , patterns , 'sh')
+  call s:detect_filetype_test('#!/usr/bin/bash'       , patterns , 'sh')
+  call s:detect_filetype_test('#!/sbin/bash'          , patterns , 'sh')
+  call s:detect_filetype_test('#!/bin/bash'           , patterns , 'sh')
+
   call s:detect_filetype_test('#!/usr/bin/env zsh'    , patterns , 'zsh')
   call s:detect_filetype_test('#!/usr/bin/env sh'     , patterns , 'sh')
   call s:detect_filetype_test('#!/usr/bin/env csh'    , patterns , 'sh')

--- a/ftdetect/shebang.vim
+++ b/ftdetect/shebang.vim
@@ -27,9 +27,9 @@ command! -nargs=* -bang AddShebangPattern
       \ call s:add_shebang_pattern(<f-args>, <bang>0)
 fun! s:add_shebang_pattern(filetype, pattern, ...) " {{{ add shebang pattern to filetype
   if a:0 == 2
-    let [post_hook, force] = [a:1, a:2]
+    let [pre_hook, force] = [a:1, a:2]
   else
-    let [post_hook, force] = ['', a:000[-1]]
+    let [pre_hook, force] = ['', a:000[-1]]
   endif
 
   try
@@ -39,7 +39,7 @@ fun! s:add_shebang_pattern(filetype, pattern, ...) " {{{ add shebang pattern to 
 
     let s:shebangs[a:pattern] = {
           \ 'filetype': a:filetype,
-          \ 'post_hook': post_hook
+          \ 'pre_hook': pre_hook
           \ }
   catch
     call shebang#error("Add shebang pattern: " . v:exception)
@@ -58,8 +58,8 @@ fun! s:shebang() " {{{ set valid filetype based on shebang line
     if empty(match)
       throw "Filetype detection failed for line: '" . line . "'"
     endif
+    exe match.pre_hook
     exe 'setfiletype ' . match.filetype
-    exe match.post_hook
   catch
     if g:shebang_enable_debug
       call shebang#error(v:exception)

--- a/ftdetect/shebang.vim
+++ b/ftdetect/shebang.vim
@@ -76,6 +76,8 @@ endf " }}}
 " /bin/env interpreter
 " /usr/bin/env interpreter
 " support most of shells: bash, sh, zsh, csh, ash, dash, ksh, pdksh, mksh, tcsh
+AddShebangPattern! sh         ^#!.*[s]\?bin/sh\>    let\ b:is_sh=1|if\ exists('b:is_bash')|unlet\ b:is_bash|endif
+AddShebangPattern! sh         ^#!.*[s]\?bin/bash\>  let\ b:is_bash=1|if\ exists('b:is_sh')|unlet\ b:is_sh|endif
 AddShebangPattern! sh         ^#!.*\s\+\(ba\|c\|a\|da\|k\|pdk\|mk\|tc\)\?sh\>
 AddShebangPattern! zsh        ^#!.*\s\+zsh\>
 " ruby

--- a/ftdetect/shebang.vim
+++ b/ftdetect/shebang.vim
@@ -25,13 +25,22 @@ let s:shebangs = {}
 
 command! -nargs=* -bang AddShebangPattern
       \ call s:add_shebang_pattern(<f-args>, <bang>0)
-fun! s:add_shebang_pattern(filetype, pattern, force) " {{{ add shebang pattern to filetype
+fun! s:add_shebang_pattern(filetype, pattern, ...) " {{{ add shebang pattern to filetype
+  if a:0 == 2
+    let [post_hook, force] = [a:1, a:2]
+  else
+    let [post_hook, force] = ['', a:000[-1]]
+  endif
+
   try
-    if !a:force && has_key(s:shebangs, a:pattern)
+    if !force && has_key(s:shebangs, a:pattern)
       throw string(a:pattern) . " is already defined, use ! to overwrite."
     endif
 
-    let s:shebangs[a:pattern] = a:filetype
+    let s:shebangs[a:pattern] = {
+          \ 'filetype': a:filetype,
+          \ 'post_hook': post_hook
+          \ }
   catch
     call shebang#error("Add shebang pattern: " . v:exception)
   endtry
@@ -45,11 +54,12 @@ fun! s:shebang() " {{{ set valid filetype based on shebang line
       return
     endif
 
-    let type = shebang#detect_filetype(line, s:shebangs)
-    if empty(type)
+    let match = shebang#detect_filetype(line, s:shebangs)
+    if empty(match)
       throw "Filetype detection failed for line: '" . line . "'"
     endif
-    exe 'setfiletype ' . type
+    exe 'setfiletype ' . match.filetype
+    exe match.post_hook
   catch
     if g:shebang_enable_debug
       call shebang#error(v:exception)


### PR DESCRIPTION
This allow to execute user-defined command when pattern match found, as per #1. The function uses `<f-args>` to hold arguments list, so each tab and white space should be escaped with one backslash (see `:h <f-args>` for more details).

For example it’s possible to explicitly set some variables after filetype is set:

``` viml
AddShebangPattern  sh  ^#!/bin/sh  let\ g:is_sh=1
```

---

@oryband, can you please add any feedback about this feature?
