### PR TITLE
Update shebang.vim

### DIFF
--- a/ftdetect/shebang.vim
+++ b/ftdetect/shebang.vim
@@ -89,7 +89,7 @@ AddShebangPattern! ruby       ^#!.*[s]\?bin/ruby\>
 AddShebangPattern! python     ^#!.*\s\+python\>
 AddShebangPattern! python     ^#!.*[s]\?bin/python\>
 " js
-AddShebangPattern! javascript ^#!.*\s\+node\>
+AddShebangPattern! javascript ^#!.*\s\+node\>   let\ b:compiled_js_files=["ts","cjs","coffee"]\ if\ index(b:compiled_js_files, expand('%:e'))|throw\ "Not javascript."|endif
 
 " }}}
 " Key bindings {{{


### PR DESCRIPTION
A stab at https://github.com/vitalk/vim-shebang/issues/7

Add a function to the pre_hook:
Adds three programming languages, coffeescript, typescript and clojurescript.
Get the file extension of the file, `expand("%:e")`. Check if the file extension exists in the above list.